### PR TITLE
removed the range operator from the operator ignore list

### DIFF
--- a/source/analyzer/rules/OperatorSpacingRule.ts
+++ b/source/analyzer/rules/OperatorSpacingRule.ts
@@ -24,7 +24,6 @@ class OperatorSpacingRule implements Rule {
 					case TokenKind.OperatorGreaterThan:
 					case TokenKind.OperatorAssign:
 					case TokenKind.OperatorNot:
-					case TokenKind.OperatorRange:
 					case TokenKind.OperatorConditional:
 					case TokenKind.OperatorExponent:
 					case TokenKind.OperatorNegate:


### PR DESCRIPTION
A violation will now be triggered if the range operator `..` does not have a space before, after or both.

`for (i in 0..n)` **not ok**
`for (i in 0 ..n)` **not ok**
`for (i in 0.. n)` **not ok**
`for (i in 0 .. n)` **ok**
