### PR TITLE
Improved command line handling and EmptyLines rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Very, very early alpha stage.
 * The analyzer will work with a proper parse tree, once implemented.
 This will enable more complex checks. Right now, a limited set of checks has been hacked together using the
 token list generated from each file.
-* Command line arguments are not implemented (except for -f).
 * A tab width of 4 is assumed.
 
 #requirements
@@ -73,9 +72,15 @@ with a lot of violations, redirecting to a file is recommended.
 ```
 ./magic ~/projects/my_awesome_project/source > violations.txt
 ```
-If you want to run the analyzer on a single file, use __-f__ (this does not work with the binary yet)
+If you want to run the analyzer on a single file, simply specify the filename.
+You may also specify a list of files, separated by a space.
 ```
-./magic -f ~/projects/my_awesome_project/source/math/Quaternion.ooc
+./magic ~/projects/my_awesome_project/source/math/Quaternion.ooc
+```
+If your shell supports wildcard expansion, you may also specify wildcards to
+process files that match a certain pattern, for example, to analyze all files that start with __Matrix__:
+```
+./magic ~/projects/my_awesome_project/source/math/Matrix*.ooc
 ```
 
 ###ignore list

--- a/source/analyzer/rules/EmptyLinesRule.ts
+++ b/source/analyzer/rules/EmptyLinesRule.ts
@@ -11,38 +11,59 @@ class EmptyLinesRule implements Rule {
 	run(tokens: Array<Token>, report: Report) {
 		var linefeeds = 0;
 		var linefeedLocation: TokenLocation;
-		var previous = Token.empty;
+		var foundLeftCurly = false;
 		for (var i = 0; i < tokens.length; i++) {
-			if (tokens[i].kind == TokenKind.WhitespaceLineFeed) {
-				var enough = false;
-				linefeedLocation = tokens[i + 1].location;
-				while (!enough) {
-					i++;
-					switch (tokens[i].kind) {
-						case TokenKind.WhitespaceLineFeed:
-							linefeeds++;
-							break;
-						case TokenKind.WhitespaceSpace:
-						case TokenKind.WhitespaceTab:
-							break;
-						default:
-							enough = true;
-							break;
+			switch (tokens[i].kind) {
+				case TokenKind.WhitespaceLineFeed:
+					var enough = false;
+					linefeedLocation = tokens[i + 1].location;
+					while (!enough) {
+						i++;
+						switch (tokens[i].kind) {
+							case TokenKind.WhitespaceLineFeed:
+								linefeeds++;
+								break;
+							case TokenKind.WhitespaceSpace:
+							case TokenKind.WhitespaceTab:
+								break;
+							case TokenKind.SeparatorRightCurly:
+								foundLeftCurly = false;
+							default:
+								enough = true;
+								break;
+						}
 					}
-				}
+					break;
+				case TokenKind.SeparatorLeftCurly:
+					foundLeftCurly = true;
+					break;
+				case TokenKind.WhitespaceSpace:
+				case TokenKind.WhitespaceTab:
+				case TokenKind.LineComment:
+				case TokenKind.BlockComment:
+					break;
+				default:
+					foundLeftCurly = false;
+					break;
 			}
 			if (linefeeds > 0 && tokens[i].kind == TokenKind.Eof) {
 				report.addViolation(new Violation(linefeedLocation,
 					"unnecessary empty line(s) before end of file", RuleKind.Whitespace));
-			} else if (linefeeds > 0 && tokens[i].kind == TokenKind.SeparatorRightCurly) {
+			}
+			if (linefeeds > 0 && foundLeftCurly) {
+				report.addViolation(new Violation(linefeedLocation,
+					"unnecessary empty line(s) after opening curly", RuleKind.Whitespace));
+				foundLeftCurly = false;
+			}
+			if (linefeeds > 0 && tokens[i].kind == TokenKind.SeparatorRightCurly) {
 				report.addViolation(new Violation(linefeedLocation,
 					"unnecessary empty line(s) before closing curly", RuleKind.Whitespace));
-			}else if (linefeeds > 1) {
+			}
+			if (linefeeds > 1) {
 				report.addViolation(new Violation(linefeedLocation,
 					"too many empty lines: " + linefeeds, RuleKind.Whitespace));
 			}
 			linefeeds = 0;
-			previous = tokens[i];
 		}
 	}
 }

--- a/source/magic.ts
+++ b/source/magic.ts
@@ -40,14 +40,17 @@ class Magic {
 		this.analyzerRules.push(new EmptyLinesRule());
 		this.analyzerRules.push(new ExcessiveSpaceRule());
 		this.analyzerRules.push(new SemicolonRule());
-		if (cmd[0] == "-f") {
-			this.analyze(cmd[1]);
-		} else {
-			if (!fs.existsSync(cmd[0])) {
-				this.throwError("The folder '" + cmd[0] + "' does not exist.");
+		cmd.forEach(argument => {
+			if (fs.existsSync(argument)) {
+				if (fs.lstatSync(argument).isDirectory()) {
+					this.analyzeDirectory(argument);
+				} else {
+					this.analyze(argument);
+				}
+			} else {
+				console.log("-> File/folder '" + argument + "' does not exist");
 			}
-			this.analyzeDirectory(cmd[0]);
-		}
+		});
 		console.log("-> magic " + Magic.version);
 	}
 

--- a/source/magic.ts
+++ b/source/magic.ts
@@ -30,7 +30,6 @@ class Magic {
 	private ignoreFiles: string[] = [];
 
 	constructor(cmd: string[]) {
-		cmd = cmd.slice(2);
 		this.analyzerRules.push(new ThisUsageRule());
 		this.analyzerRules.push(new RedundantTypeInfoRule());
 		this.analyzerRules.push(new FuncRule());
@@ -40,6 +39,10 @@ class Magic {
 		this.analyzerRules.push(new EmptyLinesRule());
 		this.analyzerRules.push(new ExcessiveSpaceRule());
 		this.analyzerRules.push(new SemicolonRule());
+		cmd = cmd.slice(2);
+		if (cmd.length == 0) {
+			cmd[0] = ".";
+		}
 		cmd.forEach(argument => {
 			if (fs.existsSync(argument)) {
 				if (fs.lstatSync(argument).isDirectory()) {
@@ -59,9 +62,7 @@ class Magic {
 	}
 
 	analyzeDirectory(directory: string) {
-		if (directory == undefined) {
-			directory = ".";
-		} else if (directory.charAt(directory.length - 1) === "/") {
+		if (directory.charAt(directory.length - 1) === "/") {
 			directory = directory.slice(0, directory.length - 1);
 		}
 		this.targetBaseDirectory = directory;
@@ -97,7 +98,7 @@ class Magic {
 						sourceFiles = sourceFiles.concat(this.getFiles(filename));
 					}
 				} else {
-					if (file.lastIndexOf(".ooc", file.length - 4) === file.length - 4) {
+					if (file.length > 4 && file.lastIndexOf(".ooc", file.length - 4) === file.length - 4) {
 						sourceFiles.push(fs.realpathSync(filename));
 					}
 				}

--- a/test/ooc/EmptyLines.ooc
+++ b/test/ooc/EmptyLines.ooc
@@ -1,9 +1,14 @@
-Foo: class {
+Foo: class { /* Empty line after opening curly */ // noise
+
 	// Two or more consecutive empty lines
 
 
 	x: Int
-	init: func
+	init: func {
+		"%d" printfln(this x)
+		// Empty line before closing curly
+
+	}
 	// An empty line before closing curly
 
 } // Unnecessary line before EOF

--- a/test/ooc/ThisUsage.ooc
+++ b/test/ooc/ThisUsage.ooc
@@ -41,4 +41,3 @@ Moobar: cover {
 		return true
 	}
 }
-


### PR DESCRIPTION
Command-line handling was improved. You can now target a specific file, a list of files or a directory, and also use wildcards, if your shell support wildcard expansion.

An EmptyLines violation will be triggered if any of the following is true:
- empty line AFTER an opening curly
- empty line BEFORE a closing curly
- 2 or more empty lines between closing curly and EOF (1 empty is allowed, since many editors inject an empty line before EOF upon saving)
- 2 or more empty lines
