### PR TITLE
Improved SeparatorSpacing rule

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 **Table of Contents**
+- [0.1.9-alpha](#019-alpha)
 - [0.1.8-alpha](#018-alpha)
 - [0.1.7-alpha](#017-alpha)
 - [0.1.6-alpha](#016-alpha)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@
 - [0.1.3-alpha](#013-alpha)
 - [0.1.2-alpha](#012-alpha)
 
+# 0.1.9-alpha
+* Improved SeparatorSpacing to trigger if a space is missing before a ```}```, if the previous token is a literal, identifier or keyword.
+
 # 0.1.8-alpha
 
 * Improved SeparatorSpacing to act on tabs where a space was expected

--- a/source/Analyzer/Rules/SeparatorSpacing.ts
+++ b/source/Analyzer/Rules/SeparatorSpacing.ts
@@ -6,8 +6,8 @@ module Magic.Analyzer.Rules {
 			tokens.forEach(t => {
 				switch (previous.kind) {
 					case Frontend.TokenKind.SeparatorColon:
-					case Frontend.TokenKind.SeparatorLeftCurly:
 					case Frontend.TokenKind.SeparatorComma:
+					case Frontend.TokenKind.SeparatorLeftCurly:
 					case Frontend.TokenKind.SeparatorRightParanthesis:
 						if (t.kind == Frontend.TokenKind.WhitespaceTab) {
 							this.addViolation("found a TAB instead of a SPACE after separator", report, t, previous);
@@ -22,6 +22,16 @@ module Magic.Analyzer.Rules {
 									this.addViolation(message, report, t, previous);
 								}
 							}
+						}
+						break;
+					default:
+						switch (t.kind) {
+							case Frontend.TokenKind.SeparatorRightCurly:
+								var kindString = Frontend.TokenKind[previous.kind];
+								if (previous.kind == Frontend.TokenKind.Identifier || kindString.indexOf("Literal") > -1 || kindString.indexOf("Keyword") > -1) {
+									this.addViolation("missing space before separator", report, t, t);
+								}
+								break;
 						}
 						break;
 				}

--- a/source/magic.ts
+++ b/source/magic.ts
@@ -3,7 +3,7 @@ var fs = require("fs");
 
 module Magic {
 	export class MagicEntry {
-		private static version = "0.1.8-alpha";
+		private static version = "0.1.9-alpha";
 		private arguments: string[];
 
 		constructor(command: string[]) {

--- a/test/ooc/SeparatorSpacing.ooc
+++ b/test/ooc/SeparatorSpacing.ooc
@@ -1,4 +1,6 @@
 // This line should trigger three violations
 foobar: Int {	get {Int moo~foo(this x, this y)}}
+// Two violations
+test: Foobar { get {this foobar}}
 // This line should not trigger a violation
 foobar: Int { get { Int moo~foo(this x, this y) }}


### PR DESCRIPTION
Improved SeparatorSpacing to trigger if a space is missing before a `}`, if the previous token is a literal, identifier or keyword.
