### PR TITLE
Bug fixes and improved OperatorSpacing rule

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 # 0.1.9-alpha
 * Improved SeparatorSpacing to trigger if a space is missing before a ```}```, if the previous token is a literal, identifier or keyword.
+* Added ```++``` (pre-increment operator) and removed it from the operator spacing rule.
 
 # 0.1.8-alpha
 

--- a/source/Analyzer/Rules/EmptyLines.ts
+++ b/source/Analyzer/Rules/EmptyLines.ts
@@ -1,3 +1,8 @@
+/// <reference path="../../Frontend/Token" />
+/// <reference path="../../Frontend/TokenKind" />
+/// <reference path="../Report" />
+/// <reference path="Rule" />
+
 module Magic.Analyzer.Rules {
 	export class EmptyLines implements Rule {
 		constructor() { }

--- a/source/Analyzer/Rules/ExcessiveSpace.ts
+++ b/source/Analyzer/Rules/ExcessiveSpace.ts
@@ -1,3 +1,8 @@
+/// <reference path="../../Frontend/Token" />
+/// <reference path="../../Frontend/TokenKind" />
+/// <reference path="../Report" />
+/// <reference path="Rule" />
+
 module Magic.Analyzer.Rules {
 	export class ExcessiveSpace implements Rule {
 		constructor() { }

--- a/source/Analyzer/Rules/Func.ts
+++ b/source/Analyzer/Rules/Func.ts
@@ -1,3 +1,8 @@
+/// <reference path="../../Frontend/Token" />
+/// <reference path="../../Frontend/TokenKind" />
+/// <reference path="../Report" />
+/// <reference path="Rule" />
+
 module Magic.Analyzer.Rules {
 	export class Func implements Rule {
 		constructor() { }

--- a/source/Analyzer/Rules/Indentation.ts
+++ b/source/Analyzer/Rules/Indentation.ts
@@ -1,0 +1,66 @@
+/// <reference path="../../Frontend/Token" />
+/// <reference path="../../Frontend/TokenKind" />
+/// <reference path="../Report" />
+/// <reference path="Rule" />
+
+module Magic.Analyzer.Rules {
+	export class Indentation implements Rule {
+		private level = 1;
+		run(tokens: Frontend.Token[], report: Report) {
+			console.log(tokens[0].location.filename);
+			for (var i = 0; i < tokens.length; i++) {
+				switch (tokens[i].kind) {
+					case Frontend.TokenKind.KeywordClass:
+					case Frontend.TokenKind.KeywordCover:
+						while (tokens[++i].kind != Frontend.TokenKind.SeparatorLeftCurly && tokens[i].kind != Frontend.TokenKind.KeywordFrom);
+						if (tokens[i].kind != Frontend.TokenKind.KeywordFrom) {
+							i = this.scanClassBody(tokens, i + 1, report);
+						}
+						break;
+				}
+			}
+		}
+		private scanClassBody(tokens: Frontend.Token[], index: number, report: Report) {
+			var delta = 1;
+			var tabs = 0;
+			var nextIsSingleLine: boolean;
+			while (delta > 0 && tokens[index].kind != Frontend.TokenKind.Eof) {
+				switch (tokens[index].kind) {
+					case Frontend.TokenKind.SeparatorLeftCurly:
+						this.level++;
+						delta++;
+						break;
+					case Frontend.TokenKind.SeparatorRightCurly:
+						this.level--;
+						delta--;
+						break;
+					case Frontend.TokenKind.KeywordIf:
+					case Frontend.TokenKind.KeywordFrom:
+					case Frontend.TokenKind.KeywordWhile:
+						break;
+						// FALL-THROUGH
+					case Frontend.TokenKind.WhitespaceLineFeed:
+						var correctedLevel: number;
+						while (tokens[++index].kind == Frontend.TokenKind.WhitespaceTab) {
+							tabs++;
+						}
+						if (Frontend.TokenKind[tokens[index].kind].indexOf("Whitespace") < 0) {
+							correctedLevel = this.level - (tokens[index].kind == Frontend.TokenKind.SeparatorRightCurly ? 1 : 0);
+							if (correctedLevel != tabs) {
+								report.addViolation(new Violation(tokens[index].location,
+									"incorrect indentation, expected " + correctedLevel + " tabs, but found " + tabs, RuleKind.General));
+							}
+							tabs = 0;
+						}
+						index--;
+						break;
+				}
+				index++;
+			}
+			if (delta !== 0) {
+				throw Error("[Indentation] -> Expected separator delta to be zero here: '" + delta + "'");
+			}
+			return index + 1;
+		}
+	}
+}

--- a/source/Analyzer/Rules/KeywordSpacing.ts
+++ b/source/Analyzer/Rules/KeywordSpacing.ts
@@ -1,3 +1,8 @@
+/// <reference path="../../Frontend/Token" />
+/// <reference path="../../Frontend/TokenKind" />
+/// <reference path="../Report" />
+/// <reference path="Rule" />
+
 module Magic.Analyzer.Rules {
 	export class KeywordSpacing implements Rule {
 		constructor() { }

--- a/source/Analyzer/Rules/LineLength.ts
+++ b/source/Analyzer/Rules/LineLength.ts
@@ -1,3 +1,8 @@
+/// <reference path="../../Frontend/Token" />
+/// <reference path="../../Frontend/TokenKind" />
+/// <reference path="../Report" />
+/// <reference path="Rule" />
+
 module Magic.Analyzer.Rules {
 	export class LineLength implements Rule {
 		constructor(private maxLineLength: number) { }

--- a/source/Analyzer/Rules/OperatorSpacing.ts
+++ b/source/Analyzer/Rules/OperatorSpacing.ts
@@ -1,3 +1,8 @@
+/// <reference path="../../Frontend/Token" />
+/// <reference path="../../Frontend/TokenKind" />
+/// <reference path="../Report" />
+/// <reference path="Rule" />
+
 module Magic.Analyzer.Rules {
 	export class OperatorSpacing implements Rule {
 		constructor() { }

--- a/source/Analyzer/Rules/RedundantTypeInfo.ts
+++ b/source/Analyzer/Rules/RedundantTypeInfo.ts
@@ -1,3 +1,8 @@
+/// <reference path="../../Frontend/Token" />
+/// <reference path="../../Frontend/TokenKind" />
+/// <reference path="../Report" />
+/// <reference path="Rule" />
+
 module Magic.Analyzer.Rules {
 	export class RedundantTypeInfo implements Rule {
 		constructor() { }

--- a/source/Analyzer/Rules/Rule.ts
+++ b/source/Analyzer/Rules/Rule.ts
@@ -1,3 +1,8 @@
+/// <reference path="../../Frontend/Token" />
+/// <reference path="../../Frontend/TokenKind" />
+/// <reference path="../Report" />
+/// <reference path="Rule" />
+
 //
 // TODO: The analyzer should not work with a list of tokens.
 // Instead, it should work with a proper parse tree. This is just

--- a/source/Analyzer/Rules/Semicolon.ts
+++ b/source/Analyzer/Rules/Semicolon.ts
@@ -1,3 +1,8 @@
+/// <reference path="../../Frontend/Token" />
+/// <reference path="../../Frontend/TokenKind" />
+/// <reference path="../Report" />
+/// <reference path="Rule" />
+
 module Magic.Analyzer.Rules {
 	export class Semicolon implements Rule {
 		constructor() { }

--- a/source/Analyzer/Rules/SeparatorSpacing.ts
+++ b/source/Analyzer/Rules/SeparatorSpacing.ts
@@ -1,3 +1,8 @@
+/// <reference path="../../Frontend/Token" />
+/// <reference path="../../Frontend/TokenKind" />
+/// <reference path="../Report" />
+/// <reference path="Rule" />
+
 module Magic.Analyzer.Rules {
 	export class SeparatorSpacing implements Rule {
 		constructor() { }

--- a/source/Analyzer/Rules/ThisUsage.ts
+++ b/source/Analyzer/Rules/ThisUsage.ts
@@ -1,3 +1,8 @@
+/// <reference path="../../Frontend/Token" />
+/// <reference path="../../Frontend/TokenKind" />
+/// <reference path="../Report" />
+/// <reference path="Rule" />
+
 module Magic.Analyzer.Rules {
 	export class ThisUsage implements Rule {
 		private classMembers: string[] = [];

--- a/source/magic.ts
+++ b/source/magic.ts
@@ -16,6 +16,7 @@ module Magic {
 
 		analyze() {
 			var rules = [
+				new Magic.Analyzer.Rules.Indentation()/*,
 				new Magic.Analyzer.Rules.EmptyLines(),
 				new Magic.Analyzer.Rules.ExcessiveSpace(),
 				new Magic.Analyzer.Rules.KeywordSpacing(),
@@ -24,7 +25,7 @@ module Magic {
 				new Magic.Analyzer.Rules.RedundantTypeInfo(),
 				new Magic.Analyzer.Rules.Func(),
 				new Magic.Analyzer.Rules.ThisUsage(),
-				new Magic.Analyzer.Rules.Semicolon()
+				new Magic.Analyzer.Rules.Semicolon()*/
 			];
 			var analyzer = new Magic.Analyzer.Analyzer(new Frontend.Glossary(), rules);
 			analyzer.analyze(this.arguments).forEach(report => {

--- a/source/magic.ts
+++ b/source/magic.ts
@@ -16,7 +16,7 @@ module Magic {
 
 		analyze() {
 			var rules = [
-				new Magic.Analyzer.Rules.Indentation()/*,
+				/*new Magic.Analyzer.Rules.Indentation(),*/
 				new Magic.Analyzer.Rules.EmptyLines(),
 				new Magic.Analyzer.Rules.ExcessiveSpace(),
 				new Magic.Analyzer.Rules.KeywordSpacing(),
@@ -25,7 +25,7 @@ module Magic {
 				new Magic.Analyzer.Rules.RedundantTypeInfo(),
 				new Magic.Analyzer.Rules.Func(),
 				new Magic.Analyzer.Rules.ThisUsage(),
-				new Magic.Analyzer.Rules.Semicolon()*/
+				new Magic.Analyzer.Rules.Semicolon()
 			];
 			var analyzer = new Magic.Analyzer.Analyzer(new Frontend.Glossary(), rules);
 			analyzer.analyze(this.arguments).forEach(report => {

--- a/test/ooc/Indentation.ooc
+++ b/test/ooc/Indentation.ooc
@@ -1,7 +1,26 @@
 Correct: class {
+	free: override func {
+		asdf
+		while (bin count > 20) {
+			version(asdf) { Debug print("asdf") }
+			b := asdf
+		}
+		this referenceCount _count = 0
+	}
+	contains: func ~asdf (list: VectorList) -> VectorList<Int> {
+		result := VectorList<Int> new()
+		for (i in 0..list count)
+			if (this contains(list[i]))
+				result add(i)
+		result
+	}
 	func: foobar -> String {
 		if (condition)
-			"oneliner"
+			"foobar"
+		else if (condition2)
+			"koobar"
+		else
+			"moobar"
 	}
 	CorrectNested: class {
 		func: moobar -> String {

--- a/test/ooc/Indentation.ooc
+++ b/test/ooc/Indentation.ooc
@@ -1,0 +1,11 @@
+Correct: class {
+	func: foobar -> String {
+		if (condition)
+			"oneliner"
+	}
+	CorrectNested: class {
+		func: moobar -> String {
+			"hello from moobar"
+		}
+	}
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
 		"source/Analyzer/Rules/EmptyLines.ts",
 		"source/Analyzer/Rules/ExcessiveSpace.ts",
 		"source/Analyzer/Rules/Func.ts",
+		"source/Analyzer/Rules/Indentation.ts",
 		"source/Analyzer/Rules/KeywordSpacing.ts",
 		"source/Analyzer/Rules/LineLength.ts",
 		"source/Analyzer/Rules/OperatorSpacing.ts",


### PR DESCRIPTION
- Improved SeparatorSpacing to trigger if a space is missing before a `}`, if the previous token is a literal, identifier or keyword.
- Added `++` (pre-increment operator) and removed it from the operator spacing rule.
