### PR TITLE
Space no longer required between keyword and *-operator + a new rule

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,10 @@
 - [0.1.3-alpha](#013-alpha)
 - [0.1.2-alpha](#012-alpha)
 
+# 0.1.17-alpha
+* Fixed so a space is no longer required between a keyword and the ```*``` operator.
+* New rule: operator ```@``` must not have a space to the left
+
 # 0.1.16-alpha
 * New rule: whitespace is not allowed between identifier and colon in a function definition
 

--- a/source/Analyzer/Rules/KeywordSpacing.ts
+++ b/source/Analyzer/Rules/KeywordSpacing.ts
@@ -1,5 +1,7 @@
 /// <reference path="../../Frontend/Token" />
 /// <reference path="../../Frontend/TokenKind" />
+/// <reference path="../Violation" />
+/// <reference path="../RuleKind" />
 /// <reference path="../Report" />
 /// <reference path="Rule" />
 

--- a/source/Analyzer/Rules/KeywordSpacing.ts
+++ b/source/Analyzer/Rules/KeywordSpacing.ts
@@ -50,6 +50,7 @@ module Magic.Analyzer.Rules {
 							case Frontend.TokenKind.OperatorGreaterThan: // Allow This<T> etc.
 							case Frontend.TokenKind.OperatorConditional: // Allow in? etc.
 							case Frontend.TokenKind.SeparatorColon: // Allow func(class: foo) etc.
+							case Frontend.TokenKind.OperatorMultiply: // Allow This*
 								break;
 							default:
 								report.addViolation(new Violation(right.location,

--- a/source/Analyzer/Rules/KeywordSpacing.ts
+++ b/source/Analyzer/Rules/KeywordSpacing.ts
@@ -52,7 +52,8 @@ module Magic.Analyzer.Rules {
 							case Frontend.TokenKind.OperatorGreaterThan: // Allow This<T> etc.
 							case Frontend.TokenKind.OperatorConditional: // Allow in? etc.
 							case Frontend.TokenKind.SeparatorColon: // Allow func(class: foo) etc.
-							case Frontend.TokenKind.OperatorMultiply: // Allow This*
+								break;
+							case Frontend.TokenKind.OperatorMultiply: // Allow 'Keyword*'
 								break;
 							default:
 								report.addViolation(new Violation(right.location,

--- a/source/Analyzer/Rules/OperatorSpacing.ts
+++ b/source/Analyzer/Rules/OperatorSpacing.ts
@@ -18,7 +18,6 @@ module Magic.Analyzer.Rules {
 						// different things depending on the context, or are too much of a hassle
 						// to work with when reading a token list instead of a parse tree.
 						case Frontend.TokenKind.KeywordOperator:
-						case Frontend.TokenKind.OperatorDereference:
 						case Frontend.TokenKind.OperatorLessThan:
 						case Frontend.TokenKind.OperatorGreaterThan:
 						case Frontend.TokenKind.OperatorAssign:
@@ -33,6 +32,11 @@ module Magic.Analyzer.Rules {
 						case Frontend.TokenKind.OperatorLogicalOr:
 						case Frontend.TokenKind.OperatorRightShift:
 						case Frontend.TokenKind.OperatorPreIncrement:
+							break;
+						case Frontend.TokenKind.OperatorDereference:
+							if (previous.kind == Frontend.TokenKind.WhitespaceSpace)
+								report.addViolation(new Violation(t.location,
+								"found a space before operator '" + t.value + "'", RuleKind.Operator));
 							break;
 						default:
 							var left = previous;

--- a/source/Analyzer/Rules/OperatorSpacing.ts
+++ b/source/Analyzer/Rules/OperatorSpacing.ts
@@ -1,6 +1,8 @@
 /// <reference path="../../Frontend/Token" />
 /// <reference path="../../Frontend/TokenKind" />
 /// <reference path="../Report" />
+/// <reference path="../Violation" />
+/// <reference path="../RuleKind" />
 /// <reference path="Rule" />
 
 module Magic.Analyzer.Rules {

--- a/source/magic.ts
+++ b/source/magic.ts
@@ -1,5 +1,23 @@
 ///<reference path="./../typings/node/node.d.ts" />
 ///<reference path="./Analyzer/Analyzer" />
+///<reference path="./Analyzer/Rules/Indentation" />
+///<reference path="./Analyzer/Rules/EmptyLineAfterLeftCurly" />
+///<reference path="./Analyzer/Rules/EmptyLineBeforeRightCurly" />
+///<reference path="./Analyzer/Rules/EmptyLineBeforeEof" />
+///<reference path="./Analyzer/Rules/WhitespaceAtBeginningOfFile" />
+///<reference path="./Analyzer/Rules/EmptyLines" />
+///<reference path="./Analyzer/Rules/ExcessiveSpace" />
+///<reference path="./Analyzer/Rules/KeywordSpacing" />
+///<reference path="./Analyzer/Rules/OperatorSpacing" />
+///<reference path="./Analyzer/Rules/SeparatorSpacing" />
+///<reference path="./Analyzer/Rules/RedundantTypeInfo" />
+///<reference path="./Analyzer/Rules/Func" />
+///<reference path="./Analyzer/Rules/ThisUsage" />
+///<reference path="./Analyzer/Rules/Semicolon" />
+///<reference path="./Analyzer/Rules/TabInsteadOfSpace" />
+///<reference path="./Analyzer/Rules/SpaceBeforeSeparator" />
+///<reference path="./Frontend/Glossary" />
+///<reference path="./Utilities/String" />
 
 var fs = require("fs");
 

--- a/source/magic.ts
+++ b/source/magic.ts
@@ -23,7 +23,7 @@ var fs = require("fs");
 
 module Magic {
 	export class MagicEntry {
-		private static version = "0.1.16-alpha";
+		private static version = "0.1.17-alpha";
 		private arguments: string[];
 		private sortByLineNumber = false
 		constructor(command: string[]) {


### PR DESCRIPTION
- A space is no longer required between a keyword and the `*` operator
- New rule: a space is no longer permitted on the left side of `@` operator
