### PR TITLE
Some lexer and parser improvements

### DIFF
--- a/source/SyntaxTree/Declarations/Assignment.ts
+++ b/source/SyntaxTree/Declarations/Assignment.ts
@@ -13,9 +13,15 @@ module Magic.SyntaxTree.Declarations {
 	//
 	// Declare-assign
 	// ID := EXPRESSION
+	// ID: TYPE = EXPRESSION
+	// Example:
+	//	list: List<T> = List<T> new()
+	//		list 			= Type.Name
+	//		List<T> 		= Type.Identifier
+	//		List<T> new()	= Expressions.Expression
 	//
 	export class Assignment extends Declaration {
-		constructor(private left: Type.Name, private right: Expressions.Expression, tokens: Tokens.Substance[]) {
+		constructor(private left: Type.Name, private right: Expressions.Expression, private type: Type.Identifier, tokens: Tokens.Substance[]) {
 			super(left.getName(), tokens)
 		}
 		getLeft(): Type.Name {
@@ -24,15 +30,32 @@ module Magic.SyntaxTree.Declarations {
 		getRight(): Expressions.Expression {
 			return this.right
 		}
+		getType(): Type.Identifier {
+			return this.type
+		}
 		static parse(source: Source): Assignment {
 			var result: Assignment
-			if (source.peek().isIdentifier() && source.peek(1).isOperator(":=")) {
+			var shorthand = false;
+			if ((shorthand = Assignment.isDeclareAssignShorthand(source)) || Assignment.isDeclareAssign(source)) {
+				var type: Type.Identifier = undefined
 				var left = Type.Name.parse(source.clone())
-				source.next() // consume ":="
+				source.next() // consume ":=" or ":"
+				if (!shorthand) {
+					type = Type.Identifier.parse(source.clone())
+					source.next() // consume "="
+				}
 				var right = Expressions.Expression.parse(source.clone())
-				result = new Assignment(left, right, source.mark())
+				result = new Assignment(left, right, type, source.mark())
 			}
 			return result
+		}
+		// True if ID := EXPRESSION
+		private static isDeclareAssignShorthand(source: Source): boolean {
+			return source.peek().isIdentifier() && source.peek(1).isOperator(":=")
+		}
+		// True if ID: TYPE = EXPRESSION
+		private static isDeclareAssign(source: Source): boolean {
+			return source.peek().isIdentifier() && source.peek(1).isSeparator(":") && source.peek(2).isIdentifier() && source.peek(3).isOperator("=")
 		}
 	}
 	Statement.addParser(Assignment.parse)

--- a/source/SyntaxTree/Declarations/Tests/AssignmentTest.ts
+++ b/source/SyntaxTree/Declarations/Tests/AssignmentTest.ts
@@ -14,6 +14,7 @@
 /// <reference path="../Assignment" />
 /// <reference path="../../Type/Name" />
 /// <reference path="../../Expressions/Identifier" />
+/// <reference path="../../Expressions/Literals/NumberLiteral" />
 
 module Magic.SyntaxTree.Declarations.Tests {
 	import Is = Unit.Constraints.Is
@@ -25,6 +26,18 @@ module Magic.SyntaxTree.Declarations.Tests {
 				var declareAssignStatement = this.createDeclaration("a := b", handler)
 				this.expect(declareAssignStatement.getLeft().getName(), Is.Equal().To("a"))
 				this.expect((<Expressions.Identifier>declareAssignStatement.getRight()).getName(), Is.Equal().To("b"))
+			})
+			this.add("foo: Type = bar", () => {
+				var declareAssignStatement = this.createDeclaration("foo: Type = bar", handler)
+				this.expect(declareAssignStatement.getLeft().getName(), Is.Equal().To("foo"))
+				this.expect(declareAssignStatement.getType().getName(), Is.Equal().To("Type"))
+				this.expect((<Expressions.Identifier>declareAssignStatement.getRight()).getName(), Is.Equal().To("bar"))
+			})
+			this.add("foo: Float = 0.50f", () => {
+				var declareAssignStatement = this.createDeclaration("f: Float = 0.50f", handler)
+				this.expect(declareAssignStatement.getLeft().getName(), Is.Equal().To("f"))
+				this.expect(declareAssignStatement.getType().getName(), Is.Equal().To("Float"))
+				this.expect((<Expressions.Literals.NumberLiteral>declareAssignStatement.getRight()).getValue(), Is.Equal().To(0.5))
 			})
 		}
 		createDeclaration(sourceString: string, errorHandler: Error.Handler): Declarations.Assignment {

--- a/source/Tokens/Literals/Number.ts
+++ b/source/Tokens/Literals/Number.ts
@@ -86,6 +86,13 @@ module Magic.Tokens.Literals {
 						case "7": value = value * 10 + 7; original += reader.read(); break
 						case "8": value = value * 10 + 8; original += reader.read(); break
 						case "9": value = value * 10 + 9; original += reader.read(); break
+						//
+						// Handle suffixes
+						// TODO:	This will probably not be sufficient once we enable more of them.
+						//			How will we differentiate between float and double?
+						//
+						case "f": reader.read()
+							// FALL-THROUGH
 						default:
 							result = new Number(divisor ? value / divisor : value, original, reader.mark()); continue
 					}


### PR DESCRIPTION
- now supports both verbose and shorthand declare-assign (`a := b` and `a: Int = b`)
- added a fix for lexing float suffix (`0.005f`)
- Updated class declaration test - magic can now parse simple classes with non-fancy member declarations
