### PR TITLE
Require space between > and {

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+    "files.eol": "\n",
+    "editor.insertSpaces": false,
+	"editor.tabSize": 4
+}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 **Table of Contents**
+- [0.1.24-alpha](#0125-alpha)
 - [0.1.24-alpha](#0124-alpha)
 - [0.1.23-alpha](#0123-alpha)
 - [0.1.22-alpha](#0122-alpha)
@@ -22,6 +23,9 @@
 - [0.1.4-alpha](#014-alpha)
 - [0.1.3-alpha](#013-alpha)
 - [0.1.2-alpha](#012-alpha)
+
+# 0.1.25-alpha
+* Fixed so space is required between `>` and `{`
 
 # 0.1.24-alpha
 * Fixed a false positive in RedundantTypeInfo rule where it would incorrectly trigger on operator `:=`

--- a/source/Analyzer/Rules/SeparatorSpacing.ts
+++ b/source/Analyzer/Rules/SeparatorSpacing.ts
@@ -32,6 +32,11 @@ module Magic.Analyzer.Rules {
 							}
 						}
 						break;
+					case Frontend.TokenKind.OperatorGreaterThan:
+						if (t.kind == Frontend.TokenKind.SeparatorLeftCurly) {
+								report.addViolation(new Violation(t.location, "missing space before separator '" + t.value + "'", RuleKind.Operator));
+						}
+						break;
 					default:
 						switch (t.kind) {
 							case Frontend.TokenKind.SeparatorRightCurly:

--- a/source/magic.ts
+++ b/source/magic.ts
@@ -23,7 +23,7 @@ var fs = require("fs");
 
 module Magic {
 	export class MagicEntry {
-		private static version = "0.1.24-alpha";
+		private static version = "0.1.25-alpha";
 		private arguments: string[];
 		private sortByLineNumber = false
 		constructor(command: string[]) {

--- a/test/ooc/SeparatorSpacing.ooc
+++ b/test/ooc/SeparatorSpacing.ooc
@@ -6,3 +6,6 @@ test: Foobar { get {this foobar}}
 init: func ~test (capacity: Int){ /* */ }
 // This line should not trigger a violation
 foobar: Int { get { Int moo~foo(this x, this y) }}
+// One violation
+foobar: class <T>{
+}


### PR DESCRIPTION
Fixes #159
