### PR TITLE
Fixed RedundantTypeInfo bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@
 
 # 0.1.25-alpha
 * Fixed so space is required between `>` and `{`
+* Fixed a bug in the RedundantTypeInfo rule.
 
 # 0.1.24-alpha
 * Fixed a false positive in RedundantTypeInfo rule where it would incorrectly trigger on operator `:=`

--- a/source/Analyzer/Rules/RedundantTypeInfo.ts
+++ b/source/Analyzer/Rules/RedundantTypeInfo.ts
@@ -22,6 +22,8 @@ module Magic.Analyzer.Rules {
 									if (nextIsType) {
 										if (tokens[i + 1].kind == Frontend.TokenKind.OperatorMultiply) {
 											types.push(tokens[i].value + "*")
+										} else if(tokens[i + 1].kind == Frontend.TokenKind.SeparatorLeftBracket) {
+											types.push(tokens[i].value + "[]")
 										} else {
 											types.push(tokens[i].value);
 										}


### PR DESCRIPTION
Fixed a bug where `foo: func (a: Float, b: Float[])` would generate a false positive.